### PR TITLE
Changed default settings file

### DIFF
--- a/api/api/asgi.py
+++ b/api/api/asgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings.dev")
 
 application = get_asgi_application()

--- a/api/api/settings/base.py
+++ b/api/api/settings/base.py
@@ -73,27 +73,6 @@ TEMPLATES = [
 WSGI_APPLICATION = "api.wsgi.application"
 
 
-# Database
-# https://docs.djangoproject.com/en/3.2/ref/settings/#databases
-
-# DATABASES = {
-#    "default": {
-#        "ENGINE": "django.db.backends.sqlite3",
-#        "NAME": BASE_DIR / "db.sqlite3",
-#    }
-# }
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql",
-        "NAME": "community_db",
-        "USER": "postgres",
-        "PASSWORD": "1234",
-        "HOST": "db",
-        "PORT": 5432,
-    }
-}
-
 REST_FRAMEWORK = {
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 30,

--- a/api/api/settings/dev.py
+++ b/api/api/settings/dev.py
@@ -1,3 +1,10 @@
 from .base import *
 
 DEBUG = True
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "db.sqlite3",
+    }
+}

--- a/api/api/settings/prod.py
+++ b/api/api/settings/prod.py
@@ -4,7 +4,11 @@ DEBUG = False
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "community_db",
+        "USER": "postgres",
+        "PASSWORD": "1234",
+        "HOST": "db",
+        "PORT": 5432,
     }
 }

--- a/api/api/wsgi.py
+++ b/api/api/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings.dev")
 
 application = get_wsgi_application()

--- a/api/manage.py
+++ b/api/manage.py
@@ -6,7 +6,7 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings.dev")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
This makes it so running `python manage.py runserver` will use the dev settings by default.